### PR TITLE
CI: Ignore DL3015 in Hadolint to fix Infrastructure Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           dockerfile: '**/Dockerfile'
           recursive: true
-          ignore: DL3008,DL3013,DL3016,DL3018
+          ignore: DL3008,DL3013,DL3015,DL3016,DL3018
 
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `DL3015` to ignored Hadolint rules in CI to prevent lint failures.
> 
>   - **CI Configuration**:
>     - Add `DL3015` to the list of ignored rules in Hadolint in `.github/workflows/ci.yml` to prevent infrastructure lint failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Kuldeep2822k%2Faqua-ai&utm_source=github&utm_medium=referral)<sup> for e5a017ba0d29d5602c93252bef8da4d0e0df585e. You can [customize](https://app.ellipsis.dev/Kuldeep2822k/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->