### PR TITLE
Potential fix for code scanning alert no. 30: Use of externally-controlled format string

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -327,7 +327,7 @@ self.addEventListener('message', (event) => {
             cache
               .add(url)
               .catch((err) =>
-                console.warn(`[SW] Failed to pre-cache ${url}:`, err)
+                console.warn('[SW] Failed to pre-cache URL:', url, err)
               )
           )
         );


### PR DESCRIPTION
Potential fix for [https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/30](https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/30)

In general, the fix is to ensure that untrusted data are never part of a format string. Instead, the format string should be a constant (or at least trusted) string with appropriate `%s` placeholders (where applicable), and the untrusted values should be passed as additional arguments. For console methods, another safe option is to pass the untrusted values as separate arguments without using `%`-style formatting at all.

For this specific case in `frontend/public/sw.js`, the best minimal fix is to keep the log message semantics the same but move `url` out of the template literal so it is no longer part of the first string argument. We can do this by changing:

```js
console.warn(`[SW] Failed to pre-cache ${url}:`, err);
```

to something like:

```js
console.warn('[SW] Failed to pre-cache URL:', url, err);
```

or, if you prefer format placeholders:

```js
console.warn('[SW] Failed to pre-cache URL: %s', url, err);
```

Both avoid having untrusted input in the format string itself. No extra imports or helper methods are required, and the change is strictly within the `CACHE_URLS` message handler, preserving all other behavior.

Concretely:
- File: `frontend/public/sw.js`
- Around lines 323–333, inside the `urls.map((url) => ...)` block, replace the single `console.warn` line (line 330) with a safe logging pattern that keeps the first argument constant and passes `url` as a separate argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
