### PR TITLE
Potential fix for code scanning alert no. 28: Clear-text logging of sensitive information

### DIFF
--- a/data-pipeline/fetch_data.py
+++ b/data-pipeline/fetch_data.py
@@ -631,8 +631,12 @@ async def main():
         if water_data:
             print(f"\nData Preview (First Record):")
             sample = water_data[0]
+            sensitive_keys = {"latitude", "longitude"}
             for key, value in sample.items():
-                print(f"  {key}: {value}")
+                if key in sensitive_keys:
+                    print(f"  {key}: [REDACTED]")
+                else:
+                    print(f"  {key}: {value}")
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Potential fix for [https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/28](https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/28)

In general, the problem is that the code outputs potentially sensitive fields (here, geolocation coordinates and possibly other attributes) directly to standard output in clear text. To fix this, the preview should either (a) omit sensitive fields entirely, or (b) redact/approximate them before printing. The rest of the functionality (fetching and saving data) should remain unchanged; we only need to adjust how the sample record is displayed.

The best minimally invasive fix is to modify the sample-printing loop in `main()` (lines 631–635) so that it does not print raw sensitive values. We can define a small set of sensitive keys (e.g., `"latitude"`, `"longitude"`) and, when encountering those keys in the loop, print a redacted placeholder (or a generalized value) instead of the true value. Other keys and values can continue to be printed as before. This keeps the same structure and behavior of the preview while preventing clear-text exposure of coordinates (and it can be easily extended if more fields are later judged sensitive). No new imports are required; we only need to alter the loop that prints `sample`.

Concretely, in `data-pipeline/fetch_data.py`, within `main()`:
- Replace the simple `for key, value in sample.items(): print(f"  {key}: {value}")` loop with a loop that:
  - Defines a `sensitive_keys` set, e.g. `{"latitude", "longitude"}`.
  - Checks if `key in sensitive_keys`; if so, prints `"  {key}: [REDACTED]"`.
  - Otherwise, prints as before.
This directly addresses both CodeQL alert variants, because both `record["latitude"]` and `record["longitude"]` now no longer reach the sink in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
