### PR TITLE
🛡️ Sentinel: Add HTTP Parameter Pollution (HPP) Protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,9 @@
 **Vulnerability:** The login endpoint returned "Invalid credentials" significantly faster when the user did not exist (fast DB lookup) compared to when the user existed (slow bcrypt comparison). This timing difference (~100ms) allowed attackers to enumerate valid email addresses.
 **Learning:** Even with generic error messages, the _time_ taken to respond acts as a side-channel leaking information. `bcrypt.compare` is intentionally slow, making the difference obvious against a simple DB query.
 **Prevention:** Ensure authentication logic executes in constant time regardless of the user's existence. Always perform a hash comparison—using a pre-calculated dummy hash if the user is not found—to align the response timing.
+
+## 2026-01-28 - Express 5 Query Parameter Immutability
+
+**Vulnerability:** While implementing HTTP Parameter Pollution (HPP) protection, direct assignment to `req.query` was ignored because Express 5 exposes it as a getter/setter property, unlike Express 4. This could lead to security middleware failing silently if it attempts to sanitize `req.query` by reassignment.
+**Learning:** Framework upgrades can introduce subtle breaking changes in core object behavior. In Express 5, `req.query` delegates to the query parser and direct assignment might not work as expected depending on the parser configuration or property descriptors.
+**Prevention:** Use `Object.defineProperty(req, 'query', { value: sanitizedQuery, ... })` when needing to completely replace or sanitize the query object in middleware to ensure the change persists and is respected by downstream handlers.

--- a/backend/src/middleware/hpp.js
+++ b/backend/src/middleware/hpp.js
@@ -1,0 +1,39 @@
+/**
+ * HTTP Parameter Pollution (HPP) Protection Middleware
+ *
+ * Prevents HPP attacks by ensuring query parameters are strings, not arrays.
+ * If a parameter is duplicated in the query string (e.g., ?id=1&id=2),
+ * Express parses it as an array ([1, 2]). This middleware selects the last value.
+ *
+ * Note: Express 5 makes req.query a getter/setter, so we use Object.defineProperty
+ * to ensure the sanitized query object is correctly assigned.
+ */
+const hpp = (req, res, next) => {
+  if (!req.query) {
+    return next();
+  }
+
+  const newQuery = { ...req.query };
+  let modified = false;
+
+  for (const key in newQuery) {
+    if (Array.isArray(newQuery[key])) {
+      // Take the last value (standard HPP behavior)
+      newQuery[key] = newQuery[key][newQuery[key].length - 1];
+      modified = true;
+    }
+  }
+
+  if (modified) {
+    Object.defineProperty(req, 'query', {
+      value: newQuery,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  next();
+};
+
+module.exports = hpp;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ const {
   getHealthStatus,
 } = require('./db/connection');
 const { errorHandler, notFound } = require('./middleware/errorHandler');
+const hpp = require('./middleware/hpp');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -111,6 +112,9 @@ app.use((req, res, next) => {
 app.use(compression());
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true, limit: '1mb' }));
+
+// Prevent HTTP Parameter Pollution
+app.use(hpp);
 
 // Request logging (using Winston instead of Morgan for consistency)
 app.use((req, res, next) => {

--- a/backend/tests/hpp.test.js
+++ b/backend/tests/hpp.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const express = require('express');
+const hpp = require('../src/middleware/hpp');
+
+describe('HTTP Parameter Pollution (HPP) Protection Middleware', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(hpp);
+    app.get('/test', (req, res) => {
+      res.json({ query: req.query });
+    });
+  });
+
+  it('should take the last value when duplicate query parameters are provided', async () => {
+    const res = await request(app).get('/test?param=first&param=second');
+
+    expect(res.status).toBe(200);
+    expect(res.body.query.param).toBe('second');
+    expect(Array.isArray(res.body.query.param)).toBe(false);
+  });
+
+  it('should handle single values correctly', async () => {
+    const res = await request(app).get('/test?param=single');
+
+    expect(res.status).toBe(200);
+    expect(res.body.query.param).toBe('single');
+  });
+
+  it('should handle multiple different parameters', async () => {
+    const res = await request(app).get('/test?a=1&b=2&a=3');
+
+    expect(res.body.query.a).toBe('3');
+    expect(res.body.query.b).toBe('2');
+  });
+
+  it('should handle mixed array and non-array parameters', async () => {
+    const res = await request(app).get('/test?arr=1&arr=2&single=3');
+
+    expect(res.body.query.arr).toBe('2');
+    expect(res.body.query.single).toBe('3');
+  });
+
+  it('should handle no query parameters', async () => {
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(200);
+    expect(res.body.query).toEqual({});
+  });
+});


### PR DESCRIPTION
Implemented HTTP Parameter Pollution (HPP) protection middleware to secure the backend against parameter pollution attacks. This middleware ensures that duplicate query parameters are flattened to the last value, preventing potential type confusion or bypasses in downstream logic. 

The implementation handles Express 5's behavior regarding `req.query` property descriptors. Comprehensive tests were added to verify the fix.

---
*PR created automatically by Jules for task [14438280989756035178](https://jules.google.com/task/14438280989756035178) started by @Kuldeep2822k*