### PR TITLE
🛡️ Sentinel: Fix HTTP Parameter Pollution (HPP) Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,9 @@
 **Vulnerability:** The login endpoint returned "Invalid credentials" significantly faster when the user did not exist (fast DB lookup) compared to when the user existed (slow bcrypt comparison). This timing difference (~100ms) allowed attackers to enumerate valid email addresses.
 **Learning:** Even with generic error messages, the _time_ taken to respond acts as a side-channel leaking information. `bcrypt.compare` is intentionally slow, making the difference obvious against a simple DB query.
 **Prevention:** Ensure authentication logic executes in constant time regardless of the user's existence. Always perform a hash comparison—using a pre-calculated dummy hash if the user is not found—to align the response timing.
+
+## 2026-01-28 - HTTP Parameter Pollution in Express 5
+
+**Vulnerability:** The application was vulnerable to HTTP Parameter Pollution (HPP) where array query parameters could bypass validation and security filters (like `sanitizeLikeSearch`). Additionally, Express 5's `req.query` handling proved resistant to simple assignment, requiring `Object.defineProperty`.
+**Learning:** Express 5 (and potentially newer 4.x configurations) may treat `req.query` as a read-only property or getter on the prototype, making simple assignment `req.query = ...` ineffective. Middleware modifying query parameters must be robust against this.
+**Prevention:** Use a dedicated HPP middleware or validate inputs strictly against expected types (e.g., `isString()`). When modifying `req.query` in middleware, ensure properties are updated individually or use `Object.defineProperty` to replace the entire object if necessary.

--- a/backend/src/middleware/hpp.js
+++ b/backend/src/middleware/hpp.js
@@ -1,0 +1,46 @@
+/**
+ * HTTP Parameter Pollution (HPP) Protection Middleware
+ *
+ * This middleware prevents parameter pollution attacks by ensuring that query parameters
+ * are always single values (strings) rather than arrays.
+ *
+ * Attack Scenario:
+ * An attacker sends `?param=value1&param=value2`.
+ * Express parses this as `req.query.param = ['value1', 'value2']`.
+ * If the application expects a string, this can bypass validation or cause errors.
+ *
+ * Fix:
+ * This middleware iterates through `req.query` and if any value is an array,
+ * it replaces it with the last value in the array (last-value-wins strategy).
+ *
+ * Note: In Express 5, `req.query` might be read-only or a getter, so we use `Object.defineProperty`
+ * to update the query object.
+ */
+const logger = require('../utils/logger');
+
+const hppProtection = (req, res, next) => {
+  if (req.query) {
+    const newQuery = { ...req.query };
+    let modified = false;
+
+    for (const key in newQuery) {
+      if (Array.isArray(newQuery[key])) {
+        // Take the last value (standard behavior for query params)
+        newQuery[key] = newQuery[key][newQuery[key].length - 1];
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      // In Express 5, req.query might be read-only or a getter, so we need to redefine it
+      Object.defineProperty(req, 'query', {
+        value: newQuery,
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+  next();
+};
+
+module.exports = hppProtection;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ const {
   getHealthStatus,
 } = require('./db/connection');
 const { errorHandler, notFound } = require('./middleware/errorHandler');
+const hppProtection = require('./middleware/hpp');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -111,6 +112,7 @@ app.use((req, res, next) => {
 app.use(compression());
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true, limit: '1mb' }));
+app.use(hppProtection);
 
 // Request logging (using Winston instead of Morgan for consistency)
 app.use((req, res, next) => {

--- a/backend/tests/hpp.test.js
+++ b/backend/tests/hpp.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+
+// Create a spy for the 'where' method
+const whereSpy = jest.fn().mockReturnThis();
+const mockDbInstance = {
+  where: whereSpy,
+  join: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  offset: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  clone: jest.fn().mockReturnThis(),
+  count: jest.fn().mockResolvedValue([{ count: 0 }]),
+  first: jest.fn().mockResolvedValue({}),
+};
+
+// Mock database connection
+const mockDb = jest.fn(() => mockDbInstance);
+
+jest.mock('../src/db/connection', () => ({
+  db: mockDb,
+  testConnection: jest.fn().mockResolvedValue(true),
+  getHealthStatus: jest.fn().mockResolvedValue({ status: 'healthy' }),
+  closeConnection: jest.fn().mockResolvedValue(),
+}));
+
+// Mock auth middleware
+jest.mock('../src/middleware/auth', () => ({
+  authenticate: (req, res, next) => next(),
+  optionalAuth: (req, res, next) => next(),
+  authorize: () => (req, res, next) => next(),
+}));
+
+// Mock logger
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const app = require('../src/server');
+
+describe('Security: HTTP Parameter Pollution (HPP)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle duplicate query parameters by taking the last value', async () => {
+    // Send a request with duplicate 'state' parameters
+    // ?state=California&state=Texas
+    // Without HPP protection, req.query.state would be ['California', 'Texas']
+    // With HPP protection, req.query.state should be 'Texas'
+
+    const res = await request(app)
+      .get('/api/locations')
+      .query('state=California')
+      .query('state=Texas');
+
+    expect(res.status).toBe(200);
+
+    // Verify that the database query was constructed with the last value
+    // The route handler calls: query.where('ls.state', 'ilike', `%${sanitizeLikeSearch(state)}%`)
+
+    // Check calls to .where()
+    // We expect one of the calls to be for 'ls.state' with value containing 'Texas'
+    const calls = whereSpy.mock.calls;
+    const stateCall = calls.find(call => call[0] === 'ls.state');
+
+    expect(stateCall).toBeDefined();
+    expect(stateCall[2]).toContain('Texas');
+    expect(stateCall[2]).not.toContain('California');
+  });
+
+  it('should handle single query parameter correctly', async () => {
+    await request(app)
+      .get('/api/locations')
+      .query({ state: 'Florida' })
+      .expect(200);
+
+    const calls = whereSpy.mock.calls;
+    const stateCall = calls.find(call => call[0] === 'ls.state');
+
+    expect(stateCall).toBeDefined();
+    expect(stateCall[2]).toContain('Florida');
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix HTTP Parameter Pollution

**Severity:** HIGH
**Vulnerability:** HTTP Parameter Pollution (HPP) allows attackers to supply multiple query parameters with the same name (e.g., `?state=A&state=B`), causing Express to parse them as an array. This array type bypasses string-based validation and sanitization functions like `sanitizeLikeSearch`, potentially allowing SQL injection or logic errors.
**Impact:** Attackers could bypass filters or cause unexpected application behavior. Specifically, `sanitizeLikeSearch(['%'])` returns an empty string, allowing a wildcard match `%%` in SQL queries.
**Fix:** Implemented custom HPP middleware that enforces a "last-value-wins" strategy for all query parameters, ensuring they are always strings.
**Verification:** Added `backend/tests/hpp.test.js` which verifies that duplicate parameters are flattened and handled correctly. Ran `npm test` to confirm.

---
*PR created automatically by Jules for task [8552660466133742000](https://jules.google.com/task/8552660466133742000) started by @Kuldeep2822k*