### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTTP Parameter Pollution vulnerability

### DIFF
--- a/backend/src/middleware/hpp.js
+++ b/backend/src/middleware/hpp.js
@@ -1,0 +1,44 @@
+/**
+ * HTTP Parameter Pollution (HPP) Protection Middleware
+ * Prevents HPP attacks by enforcing a last-value-wins strategy for duplicate query parameters.
+ *
+ * Example: ?state=CA&state=NY -> req.query.state = 'NY'
+ */
+
+const hpp = (req, res, next) => {
+  // If no query parameters, skip
+  if (!req.query) {
+    return next();
+  }
+
+  // Use a new object to avoid potential read-only issues with req.query properties
+  const newQuery = { ...req.query };
+  let modified = false;
+
+  // Iterate over query parameters
+  for (const key in newQuery) {
+    if (Object.prototype.hasOwnProperty.call(newQuery, key)) {
+      if (Array.isArray(newQuery[key])) {
+        // Take the last value (last-value-wins strategy)
+        newQuery[key] = newQuery[key][newQuery[key].length - 1];
+        modified = true;
+      }
+    }
+  }
+
+  // If we modified anything, update req.query
+  if (modified) {
+    // In Express 5+, req.query might be read-only property, so we use Object.defineProperty
+    // to force overwrite it.
+    Object.defineProperty(req, 'query', {
+      value: newQuery,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  next();
+};
+
+module.exports = hpp;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -36,6 +36,7 @@ if (process.env.NODE_ENV === 'production') {
 
 // Security middleware
 app.use(helmet());
+app.use(require('./middleware/hpp'));
 
 // CORS configuration with multiple origins
 const allowedOrigins = [

--- a/backend/tests/hpp.test.js
+++ b/backend/tests/hpp.test.js
@@ -1,0 +1,109 @@
+const request = require('supertest');
+const hpp = require('../src/middleware/hpp');
+
+// Mock database methods
+const mockWhere = jest.fn().mockReturnThis();
+const mockDbInstance = {
+  join: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  where: mockWhere,
+  orWhere: jest.fn().mockReturnThis(),
+  clone: jest.fn().mockReturnThis(),
+  clearSelect: jest.fn().mockReturnThis(),
+  count: jest.fn().mockResolvedValue([{ count: 0 }]),
+  orderBy: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  offset: jest.fn().mockReturnThis(),
+  avg: jest.fn().mockReturnThis(),
+  distinct: jest.fn().mockReturnThis(),
+  pluck: jest.fn().mockReturnThis(),
+};
+
+// Mock database connection
+const mockDb = jest.fn(() => mockDbInstance);
+
+jest.mock('../src/db/connection', () => ({
+  db: mockDb,
+  testConnection: jest.fn().mockResolvedValue(true),
+  getHealthStatus: jest.fn().mockResolvedValue({ status: 'healthy' }),
+  closeConnection: jest.fn().mockResolvedValue(),
+}));
+
+// Mock auth middleware
+jest.mock('../src/middleware/auth', () => ({
+  optionalAuth: (req, res, next) => next(),
+  authenticate: (req, res, next) => next(),
+  generateToken: () => 'mock-token',
+  authorize: () => (req, res, next) => next(),
+}));
+
+// Mock logger
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn(),
+}));
+
+const app = require('../src/server');
+
+describe('Security: HTTP Parameter Pollution', () => {
+  describe('Integration Test', () => {
+    beforeEach(() => {
+      mockWhere.mockClear();
+    });
+
+    it('should sanitize duplicate query parameters (last-value-wins)', async () => {
+      // Make request with duplicate state parameter
+      // state=CA&state=NY
+      await request(app)
+        .get('/api/water-quality?state=CA&state=NY')
+        .expect(200);
+
+      // We expect the 'where' method to be called with the sanitized last value ('NY')
+      // sanitizeLikeSearch('NY') -> 'NY' -> ilike '%NY%'
+      expect(mockWhere).toHaveBeenCalledWith('l.state', 'ilike', '%NY%');
+    });
+  });
+
+  describe('Unit Test', () => {
+    it('should take the last value of duplicate parameters', () => {
+      const req = {
+        query: {
+          id: ['123', '456'],
+          name: 'test',
+          tags: ['a', 'b', 'c']
+        }
+      };
+      const res = {};
+      const next = jest.fn();
+
+      hpp(req, res, next);
+
+      expect(req.query.id).toBe('456');
+      expect(req.query.name).toBe('test');
+      expect(req.query.tags).toBe('c');
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should handle missing query object', () => {
+      const req = {};
+      const res = {};
+      const next = jest.fn();
+
+      hpp(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should handle non-array parameters correctly', () => {
+        const req = {
+            query: {
+                search: 'water'
+            }
+        };
+        const next = jest.fn();
+        hpp(req, {}, next);
+        expect(req.query.search).toBe('water');
+    });
+  });
+});


### PR DESCRIPTION
Implemented HTTP Parameter Pollution (HPP) protection middleware to prevent duplicate query parameters from causing issues. 

- Created `backend/src/middleware/hpp.js` which iterates over `req.query` and replaces array values (duplicates) with the last element.
- It uses `Object.defineProperty` to handle potentially read-only `req.query` in Express 5.
- Added the middleware to `backend/src/server.js` early in the chain.
- Added `backend/tests/hpp.test.js` to verify the fix and prevent regressions.
- Documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16274747303935584629](https://jules.google.com/task/16274747303935584629) started by @Kuldeep2822k*