### PR TITLE
🛡️ Sentinel: Add HPP protection middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,9 @@
 **Vulnerability:** The login endpoint returned "Invalid credentials" significantly faster when the user did not exist (fast DB lookup) compared to when the user existed (slow bcrypt comparison). This timing difference (~100ms) allowed attackers to enumerate valid email addresses.
 **Learning:** Even with generic error messages, the _time_ taken to respond acts as a side-channel leaking information. `bcrypt.compare` is intentionally slow, making the difference obvious against a simple DB query.
 **Prevention:** Ensure authentication logic executes in constant time regardless of the user's existence. Always perform a hash comparison—using a pre-calculated dummy hash if the user is not found—to align the response timing.
+
+## 2026-02-04 - HTTP Parameter Pollution in Express 5
+
+**Vulnerability:** The application was vulnerable to HTTP Parameter Pollution (HPP) where duplicate query parameters (e.g., `?status=active&status=resolved`) created arrays in `req.query`, bypassing string-based validation and potentially confusing database queries.
+**Learning:** Express 5's `req.query` handling makes direct reassignment tricky due to prototype properties or getter constraints. Modifying `req.query` in middleware requires creating a new object and using `Object.defineProperty(req, 'query', ...)` to forcibly update it.
+**Prevention:** Implement a custom HPP middleware that flattens query arrays to a single value (last-value-wins) before validation logic runs. Ensure `req.query` is strictly typed or normalized early in the middleware chain.

--- a/backend/src/middleware/hpp.js
+++ b/backend/src/middleware/hpp.js
@@ -1,0 +1,53 @@
+/**
+ * HTTP Parameter Pollution (HPP) Protection Middleware
+ *
+ * Vulnerability:
+ * Express populates `req.query` with arrays when a query parameter is repeated.
+ * Example: `?status=active&status=resolved` -> `req.query.status = ['active', 'resolved']`
+ *
+ * Impact:
+ * - Can bypass input validation that expects strings (if validators are not strict).
+ * - Can cause database errors or unexpected behavior in logic expecting strings.
+ * - Can be used for DoS attacks if logic iterates over what it expects to be a string.
+ *
+ * Fix:
+ * This middleware flattens repeated query parameters to the last value (last-value-wins),
+ * ensuring `req.query` properties are always strings (or whatever the query parser produces for a single value).
+ *
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Function} next - Express next middleware function
+ */
+const hpp = (req, res, next) => {
+  // If no query parameters, skip
+  if (!req.query) return next();
+
+  const newQuery = { ...req.query };
+  let changed = false;
+
+  for (const key in newQuery) {
+    if (Object.prototype.hasOwnProperty.call(newQuery, key)) {
+      if (Array.isArray(newQuery[key])) {
+        // Take the last value in the array
+        newQuery[key] = newQuery[key][newQuery[key].length - 1];
+        changed = true;
+      }
+    }
+  }
+
+  // If changes were made, update req.query
+  if (changed) {
+    // In Express 5, direct assignment to req.query might not work if it's a getter/setter.
+    // We use Object.defineProperty to force update the property.
+    Object.defineProperty(req, 'query', {
+      value: newQuery,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  next();
+};
+
+module.exports = hpp;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
+const hpp = require('./middleware/hpp');
 const logger = require('./utils/logger');
 const {
   testConnection,
@@ -81,6 +82,9 @@ const authLimiter = rateLimit({
 });
 app.use('/api/auth/login', authLimiter);
 app.use('/api/auth/register', authLimiter);
+
+// Prevent HTTP Parameter Pollution
+app.use(hpp);
 
 // Force HTTPS in production
 if (process.env.NODE_ENV === 'production') {

--- a/backend/tests/hpp.test.js
+++ b/backend/tests/hpp.test.js
@@ -1,0 +1,80 @@
+const request = require('supertest');
+
+// Mock database connection
+const mockWhere = jest.fn().mockReturnThis();
+// We need a mock builder that can handle clone()
+const mockBuilder = {
+  join: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  where: mockWhere,
+  clone: jest.fn().mockReturnThis(), // Returns this for simplicity
+  clearSelect: jest.fn().mockReturnThis(),
+  count: jest.fn().mockResolvedValue([{ count: 0 }]),
+  orderBy: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  offset: jest.fn().mockReturnThis(),
+  then: jest.fn((resolve) => resolve([])),
+  toSQL: jest.fn().mockReturnValue({ sql: 'mock sql' }),
+};
+// Ensure clone returns a builder-like object (itself is fine for this test)
+mockBuilder.clone.mockReturnValue(mockBuilder);
+
+const mockDb = jest.fn(() => mockBuilder);
+
+jest.mock('../src/db/connection', () => ({
+  db: mockDb,
+  testConnection: jest.fn().mockResolvedValue(true),
+  getHealthStatus: jest.fn().mockResolvedValue({ status: 'healthy' }),
+  closeConnection: jest.fn().mockResolvedValue(),
+}));
+
+// Mock auth middleware
+jest.mock('../src/middleware/auth', () => ({
+  authenticate: (req, res, next) => next(),
+  optionalAuth: (req, res, next) => next(),
+  authorize: () => (req, res, next) => next(),
+  generateToken: () => 'mock-token',
+}));
+
+// Mock logger
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn(),
+}));
+
+const app = require('../src/server');
+
+describe('Security: HTTP Parameter Pollution', () => {
+  beforeEach(() => {
+    mockWhere.mockClear();
+    jest.clearAllMocks();
+  });
+
+  it('should handle duplicate query parameters by taking the last value for "status"', async () => {
+    // "status" is not validated by express-validator, so it reaches the controller directly.
+    // Without HPP middleware, "status" will be ['active', 'resolved'].
+    // With HPP middleware, "status" will be 'resolved'.
+
+    await request(app)
+      .get('/api/alerts?status=active&status=resolved')
+      .expect(200);
+
+    const statusCall = mockWhere.mock.calls.find(call => call[0] === 'a.status');
+
+    expect(statusCall).toBeDefined();
+    // Expecting strict single value 'resolved' (the last one)
+    expect(statusCall[1]).toBe('resolved');
+  });
+
+  it('should allow validation to pass for duplicate "parameter" keys by normalizing to string', async () => {
+     // "parameter" has .isString() validation.
+     // Without HPP: ['ph', 'do'] fails .isString() -> 400 Bad Request.
+     // With HPP: 'do' passes .isString() -> 200 OK.
+
+     await request(app)
+       .get('/api/alerts?parameter=ph&parameter=DO') // Upper case for code check
+       .expect(200); // Should verify that it passes validation
+  });
+});


### PR DESCRIPTION
Implemented HTTP Parameter Pollution (HPP) protection middleware to prevent array pollution in query parameters. This fix ensures that duplicate query parameters are flattened to the last value, preventing potential validation bypasses and logic errors.
Verified with regression tests that confirm duplicate parameters are handled correctly and validation rules are respected.
Also documented a critical learning regarding Express 5 `req.query` assignment constraints.

---
*PR created automatically by Jules for task [7308940027877004573](https://jules.google.com/task/7308940027877004573) started by @Kuldeep2822k*