### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/30 * * * *' # every 30 minutes
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Define secrets at workflow level for validation
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
Potential fix for [https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/48](https://github.com/Kuldeep2822k/aqua-ai/security/code-scanning/48)

Add an explicit `permissions` block to the workflow root so all jobs inherit least-privilege access unless overridden.  
Best fix here: insert

```yml
permissions:
  contents: read
```

directly under the `on:` triggers (before `env:` is fine). This preserves current functionality (checkout and dependency installs still work) while preventing unintended broader token access if repo/org defaults are permissive or later changed.

File to change:
- `.github/workflows/data-pipeline.yml` (top-level section, after `on` / before `env`)

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
