### PR TITLE
docs: add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ fixing a typo to adding a new feature.
 3. Copy the example environment file and fill in your values:
 
    ```bash
-   cp .env.example .env.development
+   cp .env.example .env
    ```
 
 4. Start the full stack (React frontend + Node.js backend) in dev mode:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to AQUA-AI 🌊
+
+Thanks for your interest in improving **AQUA-AI**, an AI-powered water quality
+monitoring platform for India! Contributions of all sizes are welcome — from
+fixing a typo to adding a new feature.
+
+## Getting started
+
+1. **Fork** the repository and **clone** your fork locally.
+2. Install dependencies from the project root:
+
+   ```bash
+   npm install
+   ```
+
+   The `postinstall` script also installs the `backend/` and `frontend/`
+   dependencies for you.
+3. Copy the example environment file and fill in your values:
+
+   ```bash
+   cp .env.example .env.development
+   ```
+4. Start the full stack (React frontend + Node.js backend) in dev mode:
+
+   ```bash
+   npm run dev
+   ```
+
+## Project layout
+
+| Directory        | Description                              |
+| ---------------- | ---------------------------------------- |
+| `frontend/`      | React 18 + TypeScript UI                 |
+| `backend/`       | Node.js + Express API                    |
+| `ai-models/`     | Python ML models                         |
+| `data-pipeline/` | Data ingestion from government sources   |
+| `docs/`          | Project documentation                    |
+
+## Development workflow
+
+1. Create a branch off `main`:
+
+   ```bash
+   git checkout -b feat/short-description
+   ```
+2. Make your changes and keep commits focused and descriptive. We follow
+   [Conventional Commits](https://www.conventionalcommits.org/) (e.g.
+   `feat:`, `fix:`, `docs:`, `chore:`).
+3. Before opening a pull request, run the checks below.
+
+## Checks before opening a PR
+
+```bash
+npm run lint          # Lint frontend and backend
+npm run format:check  # Verify Prettier formatting
+npm test              # Run frontend and backend tests
+```
+
+To auto-format your changes, run `npm run format`.
+
+## Pull request checklist
+
+- [ ] The branch is up to date with `main`.
+- [ ] Linting, formatting, and tests pass locally.
+- [ ] Commits follow the Conventional Commits style.
+- [ ] The PR description explains **what** changed and **why**.
+
+## Reporting issues
+
+Found a bug or have a feature idea? Please
+[open an issue](https://github.com/Kuldeep2822k/aqua-ai/issues) with as much
+detail as possible — steps to reproduce, expected behavior, and screenshots
+where relevant.
+
+## Code of conduct
+
+Please be respectful and constructive in all interactions. We want AQUA-AI to
+be a welcoming project for everyone working toward safer water for India. 💧

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,13 @@ fixing a typo to adding a new feature.
 
    The `postinstall` script also installs the `backend/` and `frontend/`
    dependencies for you.
+
 3. Copy the example environment file and fill in your values:
 
    ```bash
    cp .env.example .env.development
    ```
+
 4. Start the full stack (React frontend + Node.js backend) in dev mode:
 
    ```bash
@@ -28,13 +30,13 @@ fixing a typo to adding a new feature.
 
 ## Project layout
 
-| Directory        | Description                              |
-| ---------------- | ---------------------------------------- |
-| `frontend/`      | React 18 + TypeScript UI                 |
-| `backend/`       | Node.js + Express API                    |
-| `ai-models/`     | Python ML models                         |
-| `data-pipeline/` | Data ingestion from government sources   |
-| `docs/`          | Project documentation                    |
+| Directory        | Description                            |
+| ---------------- | -------------------------------------- |
+| `frontend/`      | React 18 + TypeScript UI               |
+| `backend/`       | Node.js + Express API                  |
+| `ai-models/`     | Python ML models                       |
+| `data-pipeline/` | Data ingestion from government sources |
+| `docs/`          | Project documentation                  |
 
 ## Development workflow
 
@@ -43,6 +45,7 @@ fixing a typo to adding a new feature.
    ```bash
    git checkout -b feat/short-description
    ```
+
 2. Make your changes and keep commits focused and descriptive. We follow
    [Conventional Commits](https://www.conventionalcommits.org/) (e.g.
    `feat:`, `fix:`, `docs:`, `chore:`).


### PR DESCRIPTION
## What

Adds a new top-level `CONTRIBUTING.md` to the repository. This is a **documentation-only** change — no application code, configuration, or build behavior is affected.

## Why

The repo already had `README.md`, `LICENSE`, and `SECURITY.md`, but no contributor guide. GitHub automatically surfaces `CONTRIBUTING.md` from the new-issue and new-PR screens, so this gives newcomers a single, discoverable starting point. It also serves as a small, safe demonstration of the end-to-end pull-request workflow.

## What's in the guide

- **Getting started** — fork/clone, `npm install` (the root `postinstall` also installs `backend/` and `frontend/`), copying `.env.example`, and `npm run dev`.
- **Project layout** — a table mapping top-level directories to their roles.
- **Development workflow** — branch off `main`, [Conventional Commits](https://www.conventionalcommits.org/).
- **Checks before opening a PR** — the real `npm run lint`, `npm run format:check`, and `npm test` scripts from `package.json`.
- **PR checklist** and **Reporting issues**.

## Verification

- Ran `npx prettier --check CONTRIBUTING.md` — passes after a formatting commit, so `npm run format:check` will be green.
- Cross-checked every referenced command against the root `package.json` scripts.
- No runtime code touched, so no tests were affected.

## Explainer doc

A full write-up (background, intuition, code walkthrough, verification, alternatives, and a short quiz) lives here: [Explainer: Add CONTRIBUTING.md to aqua-ai](https://app.notion.com/p/392c0ee07add8102b03df28d81f2bbc3)

---

Opened as a **draft** for review.