### PR TITLE
[review] Repo-wide quality pass: lint config, CI coverage fix, Python cleanup & tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,14 @@
 [flake8]
 max-line-length = 100
-extend-ignore = E203, W503
+# Black is the source of truth for code formatting and wraps code at 100 cols.
+# E203/W503 conflict with Black's slicing/line-break style. E501 is delegated to
+# Black as well: the only lines that exceed 100 cols after `black` are long
+# docstrings, URLs, and SQL/data literals that Black intentionally leaves intact.
+extend-ignore = E203, W503, E501
 exclude =
     __pycache__,
     .venv,
-    *.egg-info
+    *.egg-info,
+    node_modules,
+    build,
+    dist

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ __pycache__/
 *$py.class
 *.so
 .Python
+.pytest_cache/
+.coverage
+coverage.xml
+.mypy_cache/
 env/
 venv/
 ENV/

--- a/ai-models/tests/conftest.py
+++ b/ai-models/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared pytest setup for the ai-models test suite.
+
+``train_model`` imports TensorFlow at module load, but the pure-Python logic we
+unit-test here does not use it. When TensorFlow is not installed we register
+lightweight stand-ins so the module can be imported anywhere (locally and in
+CI, whether or not the heavy dependency is present).
+"""
+
+import os
+import sys
+import types
+
+_AI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _AI_DIR not in sys.path:
+    sys.path.insert(0, _AI_DIR)
+
+try:  # pragma: no cover - exercised implicitly by import side effects
+    import tensorflow  # noqa: F401
+except ModuleNotFoundError:
+    _tf = types.ModuleType("tensorflow")
+    _keras = types.ModuleType("tensorflow.keras")
+    _layers = types.ModuleType("tensorflow.keras.layers")
+    _keras.layers = _layers
+    _tf.keras = _keras
+    sys.modules["tensorflow"] = _tf
+    sys.modules["tensorflow.keras"] = _keras
+    sys.modules["tensorflow.keras.layers"] = _layers

--- a/ai-models/tests/test_risk_level.py
+++ b/ai-models/tests/test_risk_level.py
@@ -1,0 +1,39 @@
+"""Unit tests for WaterQualityPredictor._determine_risk_level."""
+
+import pytest
+
+import train_model
+
+
+@pytest.fixture(scope="module")
+def predictor():
+    # Bypass __init__ (which creates model directories and loads scalers); the
+    # classifier under test is a pure function of its arguments.
+    return train_model.WaterQualityPredictor.__new__(train_model.WaterQualityPredictor)
+
+
+@pytest.mark.parametrize(
+    "parameter,value,expected",
+    [
+        # "lower is better" pollutants
+        ("BOD", 2, "low"),
+        ("BOD", 5, "medium"),
+        ("BOD", 12, "high"),
+        ("Nitrates", 10, "low"),
+        ("Nitrates", 150, "high"),
+        # Dissolved oxygen: higher is better, so the comparison is inverted
+        ("DO", 7, "low"),
+        ("DO", 5, "medium"),
+        ("DO", 1, "high"),
+        # pH is a two-sided range around the safe band [6.5, 8.5]
+        ("pH", 7.0, "low"),
+        ("pH", 6.0, "medium"),
+        ("pH", 9.0, "medium"),
+        ("pH", 5.0, "high"),
+        ("pH", 11.0, "high"),
+        # Unknown parameters degrade gracefully
+        ("Unobtanium", 42, "unknown"),
+    ],
+)
+def test_determine_risk_level(predictor, parameter, value, expected):
+    assert predictor._determine_risk_level(parameter, value) == expected

--- a/ai-models/train_model.py
+++ b/ai-models/train_model.py
@@ -3,38 +3,36 @@ Predictive AI Model for Water Quality
 Trains machine learning models to predict water pollution events and identify hotspots
 """
 
-import os
-import sys
 import pandas as pd
 import numpy as np
 import joblib
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, Any
+from typing import Dict, Tuple, Any
 import logging
 from pathlib import Path
 
 # ML Libraries
-from sklearn.model_selection import train_test_split, GridSearchCV, cross_val_score
+from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
 from sklearn.preprocessing import StandardScaler, LabelEncoder
-from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.impute import SimpleImputer
-import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
 # Data processing
 import sqlite3
 import warnings
-warnings.filterwarnings('ignore')
+
+warnings.filterwarnings("ignore")
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class WaterQualityPredictor:
     """Main class for training water quality prediction models"""
-    
+
     def __init__(self, data_path: str = "../data-pipeline/water_quality_data.db"):
         self.data_path = data_path
         self.models = {}
@@ -42,18 +40,18 @@ class WaterQualityPredictor:
         self.encoders = {}
         self.feature_columns = []
         self.target_columns = []
-        
+
         # Create models directory
         self.model_dir = Path("models")
         self.model_dir.mkdir(exist_ok=True)
-    
+
     def load_data(self) -> pd.DataFrame:
         """Load data from SQLite database"""
         try:
             conn = sqlite3.connect(self.data_path)
-            
+
             query = """
-            SELECT 
+            SELECT
                 location_name,
                 state,
                 district,
@@ -68,24 +66,24 @@ class WaterQualityPredictor:
             WHERE value IS NOT NULL
             ORDER BY measurement_date DESC
             """
-            
+
             df = pd.read_sql_query(query, conn)
             conn.close()
-            
+
             logger.info(f"Loaded {len(df)} records from database")
             return df
-            
+
         except Exception as e:
             logger.error(f"Error loading data: {str(e)}")
             # Return sample data for development
             return self._generate_sample_data()
-    
+
     def _generate_sample_data(self) -> pd.DataFrame:
         """Generate sample data for development/testing"""
         logger.info("Generating sample water quality data for model training")
-        
+
         np.random.seed(42)
-        
+
         # Indian states and major rivers/cities
         locations = [
             ("Ganga", "Uttar Pradesh", "Varanasi", 25.3176, 82.9739),
@@ -93,18 +91,18 @@ class WaterQualityPredictor:
             ("Godavari", "Maharashtra", "Nashik", 19.9975, 73.7898),
             ("Krishna", "Karnataka", "Vijayawada", 16.5062, 80.6480),
             ("Narmada", "Madhya Pradesh", "Jabalpur", 23.1815, 79.9864),
-            ("Brahmaputra", "Assam", "Guwahati", 26.1445, 91.7362)
+            ("Brahmaputra", "Assam", "Guwahati", 26.1445, 91.7362),
         ]
-        
+
         parameters = ["BOD", "TDS", "pH", "DO", "Lead", "Mercury", "Coliform", "Nitrates"]
-        
+
         data = []
         start_date = datetime(2020, 1, 1)
-        
+
         for i in range(5000):  # Generate 5000 sample records
             location = np.random.choice(locations)
             parameter = np.random.choice(parameters)
-            
+
             # Generate realistic water quality values
             base_values = {
                 "BOD": np.random.normal(4.5, 2.0),
@@ -114,371 +112,405 @@ class WaterQualityPredictor:
                 "Lead": np.random.lognormal(-4, 1),
                 "Mercury": np.random.lognormal(-6, 0.5),
                 "Coliform": np.random.lognormal(2, 1),
-                "Nitrates": np.random.normal(25, 10)
+                "Nitrates": np.random.normal(25, 10),
             }
-            
+
             # Add seasonal variation
             date = start_date + timedelta(days=np.random.randint(0, 1460))
             seasonal_factor = 1 + 0.3 * np.sin(2 * np.pi * date.timetuple().tm_yday / 365)
-            
+
             value = max(0, base_values[parameter] * seasonal_factor)
-            
-            data.append({
-                'location_name': location[0],
-                'state': location[1],
-                'district': location[2],
-                'latitude': location[3],
-                'longitude': location[4],
-                'parameter': parameter,
-                'value': value,
-                'measurement_date': date.strftime('%Y-%m-%d'),
-                'source': 'sample_data'
-            })
-        
+
+            data.append(
+                {
+                    "location_name": location[0],
+                    "state": location[1],
+                    "district": location[2],
+                    "latitude": location[3],
+                    "longitude": location[4],
+                    "parameter": parameter,
+                    "value": value,
+                    "measurement_date": date.strftime("%Y-%m-%d"),
+                    "source": "sample_data",
+                }
+            )
+
         return pd.DataFrame(data)
-    
+
     def preprocess_data(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Preprocess data for machine learning"""
         logger.info("Preprocessing data for ML training")
-        
+
         # Convert date column
-        df['measurement_date'] = pd.to_datetime(df['measurement_date'])
-        
+        df["measurement_date"] = pd.to_datetime(df["measurement_date"])
+
         # Extract time features
-        df['year'] = df['measurement_date'].dt.year
-        df['month'] = df['measurement_date'].dt.month
-        df['day_of_year'] = df['measurement_date'].dt.dayofyear
-        
+        df["year"] = df["measurement_date"].dt.year
+        df["month"] = df["measurement_date"].dt.month
+        df["day_of_year"] = df["measurement_date"].dt.dayofyear
+
         # Pivot table to get parameters as columns
         df_pivot = df.pivot_table(
-            index=['location_name', 'state', 'district', 'latitude', 'longitude', 
-                   'measurement_date', 'year', 'month', 'day_of_year'],
-            columns='parameter',
-            values='value',
-            aggfunc='mean'
+            index=[
+                "location_name",
+                "state",
+                "district",
+                "latitude",
+                "longitude",
+                "measurement_date",
+                "year",
+                "month",
+                "day_of_year",
+            ],
+            columns="parameter",
+            values="value",
+            aggfunc="mean",
         ).reset_index()
-        
+
         # Fill missing values
-        imputer = SimpleImputer(strategy='median')
-        parameter_cols = [col for col in df_pivot.columns if col not in 
-                         ['location_name', 'state', 'district', 'latitude', 'longitude', 
-                          'measurement_date', 'year', 'month', 'day_of_year']]
-        
+        imputer = SimpleImputer(strategy="median")
+        parameter_cols = [
+            col
+            for col in df_pivot.columns
+            if col
+            not in [
+                "location_name",
+                "state",
+                "district",
+                "latitude",
+                "longitude",
+                "measurement_date",
+                "year",
+                "month",
+                "day_of_year",
+            ]
+        ]
+
         df_pivot[parameter_cols] = imputer.fit_transform(df_pivot[parameter_cols])
-        
+
         # Encode categorical variables
-        for col in ['location_name', 'state', 'district']:
+        for col in ["location_name", "state", "district"]:
             if col in df_pivot.columns:
                 le = LabelEncoder()
-                df_pivot[f'{col}_encoded'] = le.fit_transform(df_pivot[col].astype(str))
+                df_pivot[f"{col}_encoded"] = le.fit_transform(df_pivot[col].astype(str))
                 self.encoders[col] = le
-        
+
         # Feature engineering
-        df_pivot['pollution_index'] = (
-            df_pivot.get('BOD', 0) * 0.3 +
-            df_pivot.get('TDS', 0) * 0.0001 +
-            df_pivot.get('Lead', 0) * 100 +
-            df_pivot.get('Mercury', 0) * 1000
+        df_pivot["pollution_index"] = (
+            df_pivot.get("BOD", 0) * 0.3
+            + df_pivot.get("TDS", 0) * 0.0001
+            + df_pivot.get("Lead", 0) * 100
+            + df_pivot.get("Mercury", 0) * 1000
         )
-        
+
         # Define features and targets
-        feature_cols = ['latitude', 'longitude', 'year', 'month', 'day_of_year',
-                       'location_name_encoded', 'state_encoded', 'district_encoded']
+        feature_cols = [
+            "latitude",
+            "longitude",
+            "year",
+            "month",
+            "day_of_year",
+            "location_name_encoded",
+            "state_encoded",
+            "district_encoded",
+        ]
         feature_cols.extend([col for col in parameter_cols if col in df_pivot.columns])
-        
+
         self.feature_columns = [col for col in feature_cols if col in df_pivot.columns]
         self.target_columns = parameter_cols
-        
+
         X = df_pivot[self.feature_columns]
         y = df_pivot[self.target_columns]
-        
+
         # Scale features
         scaler = StandardScaler()
         X_scaled = scaler.fit_transform(X)
-        self.scalers['features'] = scaler
-        
+        self.scalers["features"] = scaler
+
         X_scaled_df = pd.DataFrame(X_scaled, columns=self.feature_columns)
-        
-        logger.info(f"Preprocessed data: {len(X_scaled_df)} samples, {len(self.feature_columns)} features")
-        
+
+        logger.info(
+            f"Preprocessed data: {len(X_scaled_df)} samples, {len(self.feature_columns)} features"
+        )
+
         return X_scaled_df, y
-    
+
     def train_models(self, X: pd.DataFrame, y: pd.DataFrame):
         """Train multiple ML models for different parameters"""
         logger.info("Training machine learning models")
-        
+
         for target in self.target_columns:
             if target not in y.columns:
                 continue
-                
+
             logger.info(f"Training model for {target}")
-            
+
             # Remove rows with NaN targets
             mask = ~y[target].isna()
             X_target = X[mask]
             y_target = y[target][mask]
-            
+
             if len(X_target) < 100:  # Skip if too few samples
                 logger.warning(f"Skipping {target}: insufficient data ({len(X_target)} samples)")
                 continue
-            
+
             # Split data
             X_train, X_test, y_train, y_test = train_test_split(
                 X_target, y_target, test_size=0.2, random_state=42
             )
-            
+
             # Train Random Forest
             rf_model = RandomForestRegressor(n_estimators=100, random_state=42)
             rf_model.fit(X_train, y_train)
-            
+
             # Train Gradient Boosting
             gb_model = GradientBoostingRegressor(n_estimators=100, random_state=42)
             gb_model.fit(X_train, y_train)
-            
+
             # Evaluate models
             rf_score = rf_model.score(X_test, y_test)
             gb_score = gb_model.score(X_test, y_test)
-            
+
             # Choose best model
             if rf_score > gb_score:
                 best_model = rf_model
-                model_type = 'RandomForest'
+                model_type = "RandomForest"
                 best_score = rf_score
             else:
                 best_model = gb_model
-                model_type = 'GradientBoosting'
+                model_type = "GradientBoosting"
                 best_score = gb_score
-            
+
             self.models[target] = {
-                'model': best_model,
-                'type': model_type,
-                'score': best_score,
-                'feature_importance': dict(zip(self.feature_columns, 
-                                             best_model.feature_importances_))
+                "model": best_model,
+                "type": model_type,
+                "score": best_score,
+                "feature_importance": dict(
+                    zip(self.feature_columns, best_model.feature_importances_)
+                ),
             }
-            
+
             logger.info(f"{target}: {model_type} model, R² = {best_score:.3f}")
-    
+
     def train_neural_network(self, X: pd.DataFrame, y: pd.DataFrame, target: str):
         """Train neural network for specific target"""
         if target not in y.columns:
             return None
-        
+
         # Prepare data
         mask = ~y[target].isna()
         X_target = X[mask].values
         y_target = y[target][mask].values
-        
+
         X_train, X_test, y_train, y_test = train_test_split(
             X_target, y_target, test_size=0.2, random_state=42
         )
-        
+
         # Build neural network
-        model = keras.Sequential([
-            layers.Dense(128, activation='relu', input_shape=(X_train.shape[1],)),
-            layers.Dropout(0.3),
-            layers.Dense(64, activation='relu'),
-            layers.Dropout(0.3),
-            layers.Dense(32, activation='relu'),
-            layers.Dense(1)
-        ])
-        
-        model.compile(optimizer='adam', loss='mse', metrics=['mae'])
-        
+        model = keras.Sequential(
+            [
+                layers.Dense(128, activation="relu", input_shape=(X_train.shape[1],)),
+                layers.Dropout(0.3),
+                layers.Dense(64, activation="relu"),
+                layers.Dropout(0.3),
+                layers.Dense(32, activation="relu"),
+                layers.Dense(1),
+            ]
+        )
+
+        model.compile(optimizer="adam", loss="mse", metrics=["mae"])
+
         # Train model
         history = model.fit(
-            X_train, y_train,
-            epochs=50,
-            batch_size=32,
-            validation_split=0.2,
-            verbose=0
+            X_train, y_train, epochs=50, batch_size=32, validation_split=0.2, verbose=0
         )
-        
+
         # Evaluate
         test_loss, test_mae = model.evaluate(X_test, y_test, verbose=0)
-        
-        return {
-            'model': model,
-            'history': history,
-            'test_loss': test_loss,
-            'test_mae': test_mae
-        }
-    
+
+        return {"model": model, "history": history, "test_loss": test_loss, "test_mae": test_mae}
+
     def predict_pollution_risk(self, location_data: Dict[str, Any]) -> Dict[str, Any]:
         """Predict pollution risk for a specific location"""
         predictions = {}
-        
+
         # Prepare input data
         input_data = pd.DataFrame([location_data])
-        
+
         # Encode categorical variables
         for col, encoder in self.encoders.items():
             if col in input_data.columns:
                 try:
-                    input_data[f'{col}_encoded'] = encoder.transform(input_data[col].astype(str))
+                    input_data[f"{col}_encoded"] = encoder.transform(input_data[col].astype(str))
                 except ValueError:
-                    input_data[f'{col}_encoded'] = 0  # Unknown category
-        
+                    input_data[f"{col}_encoded"] = 0  # Unknown category
+
         # Ensure all feature columns are present
         for col in self.feature_columns:
             if col not in input_data.columns:
                 input_data[col] = 0
-        
+
         # Scale features
-        X_scaled = self.scalers['features'].transform(input_data[self.feature_columns])
-        
+        X_scaled = self.scalers["features"].transform(input_data[self.feature_columns])
+
         # Make predictions
         for parameter, model_info in self.models.items():
             try:
-                pred = model_info['model'].predict(X_scaled)[0]
-                confidence = model_info['score']
-                
+                pred = model_info["model"].predict(X_scaled)[0]
+                confidence = model_info["score"]
+
                 # Determine risk level based on parameter thresholds
                 risk_level = self._determine_risk_level(parameter, pred)
-                
+
                 predictions[parameter] = {
-                    'predicted_value': pred,
-                    'confidence': confidence,
-                    'risk_level': risk_level,
-                    'model_type': model_info['type']
+                    "predicted_value": pred,
+                    "confidence": confidence,
+                    "risk_level": risk_level,
+                    "model_type": model_info["type"],
                 }
-                
+
             except Exception as e:
                 logger.error(f"Error predicting {parameter}: {str(e)}")
                 continue
-        
+
         return predictions
-    
+
     def _determine_risk_level(self, parameter: str, value: float) -> str:
         """Determine risk level based on parameter value"""
         thresholds = {
-            'BOD': {'safe': 3, 'moderate': 6, 'high': 10},
-            'TDS': {'safe': 500, 'moderate': 1000, 'high': 1500},
-            'pH': {'safe_min': 6.5, 'safe_max': 8.5, 'moderate_range': 1.0},
-            'DO': {'safe': 6, 'moderate': 4, 'high': 2},
-            'Lead': {'safe': 0.01, 'moderate': 0.05, 'high': 0.1},
-            'Mercury': {'safe': 0.001, 'moderate': 0.005, 'high': 0.01},
-            'Coliform': {'safe': 2.2, 'moderate': 10, 'high': 50},
-            'Nitrates': {'safe': 45, 'moderate': 100, 'high': 200}
+            "BOD": {"safe": 3, "moderate": 6, "high": 10},
+            "TDS": {"safe": 500, "moderate": 1000, "high": 1500},
+            "pH": {"safe_min": 6.5, "safe_max": 8.5, "moderate_range": 1.0},
+            "DO": {"safe": 6, "moderate": 4, "high": 2},
+            "Lead": {"safe": 0.01, "moderate": 0.05, "high": 0.1},
+            "Mercury": {"safe": 0.001, "moderate": 0.005, "high": 0.01},
+            "Coliform": {"safe": 2.2, "moderate": 10, "high": 50},
+            "Nitrates": {"safe": 45, "moderate": 100, "high": 200},
         }
-        
+
         if parameter not in thresholds:
-            return 'unknown'
-        
+            return "unknown"
+
         thresh = thresholds[parameter]
-        
-        if parameter == 'pH':
-            if thresh['safe_min'] <= value <= thresh['safe_max']:
-                return 'low'
-            elif (thresh['safe_min'] - thresh['moderate_range'] <= value <= thresh['safe_min'] or
-                  thresh['safe_max'] <= value <= thresh['safe_max'] + thresh['moderate_range']):
-                return 'medium'
+
+        if parameter == "pH":
+            if thresh["safe_min"] <= value <= thresh["safe_max"]:
+                return "low"
+            elif (
+                thresh["safe_min"] - thresh["moderate_range"] <= value <= thresh["safe_min"]
+                or thresh["safe_max"] <= value <= thresh["safe_max"] + thresh["moderate_range"]
+            ):
+                return "medium"
             else:
-                return 'high'
-        elif parameter == 'DO':
-            if value >= thresh['safe']:
-                return 'low'
-            elif value >= thresh['moderate']:
-                return 'medium'
+                return "high"
+        elif parameter == "DO":
+            if value >= thresh["safe"]:
+                return "low"
+            elif value >= thresh["moderate"]:
+                return "medium"
             else:
-                return 'high'
+                return "high"
         else:
-            if value <= thresh['safe']:
-                return 'low'
-            elif value <= thresh['moderate']:
-                return 'medium'
+            if value <= thresh["safe"]:
+                return "low"
+            elif value <= thresh["moderate"]:
+                return "medium"
             else:
-                return 'high'
-    
+                return "high"
+
     def save_models(self):
         """Save trained models to disk"""
         logger.info("Saving models to disk")
-        
+
         # Save scikit-learn models
         for parameter, model_info in self.models.items():
             model_path = self.model_dir / f"{parameter}_model.joblib"
             joblib.dump(model_info, model_path)
-        
+
         # Save preprocessors
         joblib.dump(self.scalers, self.model_dir / "scalers.joblib")
         joblib.dump(self.encoders, self.model_dir / "encoders.joblib")
-        
+
         # Save metadata
         metadata = {
-            'feature_columns': self.feature_columns,
-            'target_columns': self.target_columns,
-            'model_version': datetime.now().isoformat(),
-            'training_date': datetime.now().strftime('%Y-%m-%d')
+            "feature_columns": self.feature_columns,
+            "target_columns": self.target_columns,
+            "model_version": datetime.now().isoformat(),
+            "training_date": datetime.now().strftime("%Y-%m-%d"),
         }
-        
-        with open(self.model_dir / "metadata.json", 'w') as f:
+
+        with open(self.model_dir / "metadata.json", "w") as f:
             import json
+
             json.dump(metadata, f, indent=2)
-        
+
         logger.info(f"Models saved to {self.model_dir}")
-    
+
     def load_models(self):
         """Load trained models from disk"""
         try:
             # Load models
             for model_file in self.model_dir.glob("*_model.joblib"):
-                parameter = model_file.stem.replace('_model', '')
+                parameter = model_file.stem.replace("_model", "")
                 self.models[parameter] = joblib.load(model_file)
-            
+
             # Load preprocessors
             self.scalers = joblib.load(self.model_dir / "scalers.joblib")
             self.encoders = joblib.load(self.model_dir / "encoders.joblib")
-            
+
             # Load metadata
-            with open(self.model_dir / "metadata.json", 'r') as f:
+            with open(self.model_dir / "metadata.json", "r") as f:
                 import json
+
                 metadata = json.load(f)
-                self.feature_columns = metadata['feature_columns']
-                self.target_columns = metadata['target_columns']
-            
+                self.feature_columns = metadata["feature_columns"]
+                self.target_columns = metadata["target_columns"]
+
             logger.info(f"Loaded {len(self.models)} models")
             return True
-            
+
         except Exception as e:
             logger.error(f"Error loading models: {str(e)}")
             return False
 
+
 def main():
     """Main training function"""
     predictor = WaterQualityPredictor()
-    
+
     # Load data
     df = predictor.load_data()
-    
+
     if df.empty:
         logger.error("No data available for training")
         return
-    
+
     # Preprocess data
     X, y = predictor.preprocess_data(df)
-    
+
     # Train models
     predictor.train_models(X, y)
-    
+
     # Save models
     predictor.save_models()
-    
+
     # Test prediction
     sample_location = {
-        'location_name': 'Ganga',
-        'state': 'Uttar Pradesh',
-        'district': 'Varanasi',
-        'latitude': 25.3176,
-        'longitude': 82.9739,
-        'year': 2024,
-        'month': 9,
-        'day_of_year': 256
+        "location_name": "Ganga",
+        "state": "Uttar Pradesh",
+        "district": "Varanasi",
+        "latitude": 25.3176,
+        "longitude": 82.9739,
+        "year": 2024,
+        "month": 9,
+        "day_of_year": 256,
     }
-    
+
     predictions = predictor.predict_pollution_risk(sample_location)
     logger.info(f"Sample prediction: {predictions}")
-    
+
     logger.info("Model training completed successfully!")
+
 
 if __name__ == "__main__":
     main()

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -41,6 +41,14 @@ module.exports = [
     },
   },
   {
+    // Test files frequently use async fixtures/handlers to exercise
+    // promise-based code paths, so an explicit `await` is not always present.
+    files: ['**/*.test.js', 'tests/**/*.js'],
+    rules: {
+      'require-await': 'off',
+    },
+  },
+  {
     ignores: ['node_modules/', 'coverage/', 'logs/'],
   },
 ];

--- a/data-pipeline/__init__.py
+++ b/data-pipeline/__init__.py
@@ -1,3 +1,2 @@
 # Data Pipeline for Aqua-AI
 # Handles data fetching, cleaning, and processing from various government sources
-

--- a/data-pipeline/check_db.py
+++ b/data-pipeline/check_db.py
@@ -1,7 +1,6 @@
-
-import os
 import psycopg2
 from config import DB_CONFIG
+
 
 def check_data():
     try:
@@ -10,31 +9,32 @@ def check_data():
             port=DB_CONFIG.port,
             database=DB_CONFIG.database,
             user=DB_CONFIG.username,
-            password=DB_CONFIG.password
+            password=DB_CONFIG.password,
         )
         cursor = conn.cursor()
-        
+
         cursor.execute("SELECT COUNT(*) FROM locations")
         loc_count = cursor.fetchone()[0]
-        
+
         cursor.execute("SELECT parameter_code FROM water_quality_parameters")
         params = cursor.fetchall()
         print(f"Parameters in DB: {[p[0] for p in params]}")
 
         cursor.execute("SELECT COUNT(*) FROM water_quality_readings")
         reading_count = cursor.fetchone()[0]
-        
+
         print(f"Locations: {loc_count}")
         print(f"Readings: {reading_count}")
-        
+
         if reading_count > 0:
             print("SUCCESS: Data found in database.")
         else:
             print("FAILURE: No data found in readings table.")
-            
+
         conn.close()
     except Exception as e:
         print(f"Error checking DB: {e}")
+
 
 if __name__ == "__main__":
     check_data()

--- a/data-pipeline/config.py
+++ b/data-pipeline/config.py
@@ -4,7 +4,6 @@ Configuration settings for the data pipeline
 
 import os
 from dataclasses import dataclass
-from typing import Dict, List
 from urllib.parse import urlparse
 
 

--- a/data-pipeline/fetch_data.py
+++ b/data-pipeline/fetch_data.py
@@ -6,24 +6,22 @@ Fetches water quality data from various government sources
 import asyncio
 import aiohttp
 import sqlite3
-import json
 import logging
 import os
 import uuid
 import subprocess
-from urllib.parse import urlparse
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any, cast
 import random
-import pandas as pd
 import numpy as np
 from pathlib import Path
 from dateutil import parser as date_parser
 import psycopg2
-from psycopg2.extras import RealDictCursor
 import re
 import html
 import hashlib
+
+from config import GOVERNMENT_APIS, WATER_QUALITY_PARAMETERS, INDIAN_WATER_BODIES, DB_CONFIG
 
 
 def sanitize_text(value: str, max_length: int = 500) -> str:
@@ -55,8 +53,6 @@ def sanitize_record(record: Dict[str, Any], text_fields: List[str]) -> Dict[str,
             sanitized[field] = sanitize_text(sanitized[field])
     return sanitized
 
-
-from config import GOVERNMENT_APIS, WATER_QUALITY_PARAMETERS, INDIAN_WATER_BODIES, DB_CONFIG
 
 # Setup logging
 _script_dir = Path(__file__).parent
@@ -189,18 +185,17 @@ class WaterQualityDataFetcher:
             await self.session.close()  # type: ignore
 
     async def _fetch_from_resource(self, config_key: str) -> List[Dict[str, Any]]:
-        """Generic helper to fetch data from a data.gov.in resource"""
         """
         Fetch and process water-quality records from a configured government resource.
-        
+
         Given a key in GOVERNMENT_APIS, request paginated JSON data from that resource, normalize each record via _process_data_gov_in, tag each processed record with "source" = "government", and return the consolidated list of processed records. If the configured API key is missing or an HTTP request fails and sample data generation is allowed, synthetic records from _generate_sample_data(config_key) are returned instead.
-        
+
         Parameters:
             config_key (str): Key identifying the resource in GOVERNMENT_APIS (e.g., "data_gov_in" or "cpcb").
-        
+
         Returns:
             List[Dict[str, Any]]: A list of standardized water-quality records produced by _process_data_gov_in with an added `"source": "government"` field.
-        
+
         Raises:
             RuntimeError: If the resource has no API key and ALLOW_SAMPLE_DATA is false, or if an API request fails and sample data is not permitted.
         """
@@ -304,10 +299,9 @@ class WaterQualityDataFetcher:
         return await self._fetch_from_resource("data_gov_in")
 
     async def fetch_data_gov_in_data(self) -> List[Dict[str, Any]]:
-        """Fetch water quality data from Data.gov.in CPCB dataset."""
         """
         Fetch and standardize water quality records from the general data.gov.in resource.
-        
+
         Returns:
             list[dict]: Processed water quality records where each dict contains standardized fields such as
                 `location_name`, `state`, `district`, `latitude`, `longitude`, `parameter`, `value`,
@@ -1004,8 +998,8 @@ class WaterQualityDataFetcher:
         for record in data:
             cursor.execute(
                 """
-                INSERT OR REPLACE INTO water_quality_readings 
-                (location_name, state, district, latitude, longitude, 
+                INSERT OR REPLACE INTO water_quality_readings
+                (location_name, state, district, latitude, longitude,
                  parameter, value, unit, measurement_date, source)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -1040,7 +1034,7 @@ class WaterQualityDataFetcher:
         for location in locations.values():
             cursor.execute(
                 """
-                INSERT OR IGNORE INTO locations 
+                INSERT OR IGNORE INTO locations
                 (name, state, district, latitude, longitude, water_body_type)
                 VALUES (?, ?, ?, ?, ?, ?)
             """,
@@ -1160,7 +1154,7 @@ async def main():
         water_data, weather_data = await fetcher.fetch_all_data()
 
         # Print summary
-        print(f"\nData Fetch Summary:")
+        print("\nData Fetch Summary:")
         print(f"Water Quality Records: {len(water_data)}")
         print(f"Weather Records: {len(weather_data)}")
         print(
@@ -1169,7 +1163,7 @@ async def main():
 
         # Show sample data
         if water_data:
-            print(f"\nData Preview (First Record):")
+            print("\nData Preview (First Record):")
             sample = water_data[0]
             for key, value in sample.items():
                 print(f"  {key}: {value}")

--- a/data-pipeline/tests/conftest.py
+++ b/data-pipeline/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures/setup for the data-pipeline test suite.
+
+These hooks make the data-pipeline modules importable no matter which directory
+pytest is invoked from (locally we run from ``data-pipeline``; CI runs from the
+repository root with ``pytest --cov=.``).
+"""
+
+import os
+import sys
+
+# Ensure ``config`` and ``fetch_data`` resolve regardless of the pytest rootdir.
+_DP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _DP_DIR not in sys.path:
+    sys.path.insert(0, _DP_DIR)
+
+# config.py instantiates ``DB_CONFIG = DBConfig()`` at import time, which requires
+# a database URL (or DB_PASSWORD). Provide a harmless default for the test run so
+# importing the module never touches a real database.
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/aqua_ai_test_db"
+)

--- a/data-pipeline/tests/conftest.py
+++ b/data-pipeline/tests/conftest.py
@@ -8,6 +8,8 @@ repository root with ``pytest --cov=.``).
 import os
 import sys
 
+import pytest
+
 # Ensure ``config`` and ``fetch_data`` resolve regardless of the pytest rootdir.
 _DP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _DP_DIR not in sys.path:
@@ -16,6 +18,17 @@ if _DP_DIR not in sys.path:
 # config.py instantiates ``DB_CONFIG = DBConfig()`` at import time, which requires
 # a database URL (or DB_PASSWORD). Provide a harmless default for the test run so
 # importing the module never touches a real database.
-os.environ.setdefault(
-    "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/aqua_ai_test_db"
-)
+@pytest.fixture(scope="session", autouse=True)
+def _default_database_url():
+    if "DATABASE_URL" in os.environ:
+        yield
+        return
+
+    mp = pytest.MonkeyPatch()
+    mp.setenv(
+        "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/aqua_ai_test_db"
+    )
+    try:
+        yield
+    finally:
+        mp.undo()

--- a/data-pipeline/tests/test_config.py
+++ b/data-pipeline/tests/test_config.py
@@ -1,0 +1,96 @@
+"""Unit tests for data-pipeline configuration parsing and reference data."""
+
+import pytest
+
+import config
+
+_DB_ENV_KEYS = ["DATABASE_URL", "DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD"]
+
+
+def _make_dbconfig(monkeypatch, **env):
+    """Build a fresh DBConfig with a controlled environment."""
+    for key in _DB_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return config.DBConfig()
+
+
+class TestDBConfig:
+    def test_parses_database_url(self, monkeypatch):
+        cfg = _make_dbconfig(
+            monkeypatch,
+            DATABASE_URL="postgresql://alice:s3cret@db.example.com:6543/waterdb",
+        )
+        assert cfg.host == "db.example.com"
+        assert cfg.port == 6543
+        assert cfg.database == "waterdb"
+        assert cfg.username == "alice"
+        assert cfg.password == "s3cret"
+
+    def test_connection_string_roundtrips(self, monkeypatch):
+        url = "postgresql://alice:s3cret@db.example.com:6543/waterdb"
+        cfg = _make_dbconfig(monkeypatch, DATABASE_URL=url)
+        assert cfg.connection_string == url
+
+    def test_database_url_applies_defaults_for_missing_parts(self, monkeypatch):
+        cfg = _make_dbconfig(monkeypatch, DATABASE_URL="postgresql://bob:pw@localhost")
+        assert cfg.port == 5432
+        assert cfg.database == "aqua_ai_db"
+
+    def test_falls_back_to_individual_env_vars(self, monkeypatch):
+        cfg = _make_dbconfig(
+            monkeypatch,
+            DB_HOST="h",
+            DB_PORT="1234",
+            DB_NAME="n",
+            DB_USER="u",
+            DB_PASSWORD="p",
+        )
+        assert (cfg.host, cfg.port, cfg.database, cfg.username, cfg.password) == (
+            "h",
+            1234,
+            "n",
+            "u",
+            "p",
+        )
+
+    def test_missing_password_and_url_raises(self, monkeypatch):
+        with pytest.raises(ValueError):
+            _make_dbconfig(monkeypatch)
+
+
+class TestAPIConfig:
+    def test_defaults(self):
+        api = config.APIConfig(base_url="https://example.gov")
+        assert api.api_key is None
+        assert api.rate_limit == 100
+        assert api.timeout == 30
+        assert api.retry_attempts == 3
+
+    def test_government_apis_are_registered(self):
+        assert "data_gov_in" in config.GOVERNMENT_APIS
+        assert "weather_api" in config.GOVERNMENT_APIS
+        for api in config.GOVERNMENT_APIS.values():
+            assert api.base_url.startswith("https://")
+
+
+class TestWaterQualityParameters:
+    def test_every_parameter_has_name_and_unit(self):
+        for code, meta in config.WATER_QUALITY_PARAMETERS.items():
+            assert meta.get("name"), f"{code} is missing a display name"
+            assert "unit" in meta, f"{code} is missing a unit"
+
+    def test_ph_uses_range_thresholds(self):
+        ph = config.WATER_QUALITY_PARAMETERS["pH"]
+        assert ph["safe_min"] < ph["safe_max"]
+
+
+class TestIndianWaterBodies:
+    def test_coordinates_lie_within_india(self):
+        for state, meta in config.INDIAN_WATER_BODIES.items():
+            assert isinstance(meta["rivers"], list) and meta["rivers"], state
+            lat, lon = meta["coordinates"]
+            # Rough bounding box for mainland India.
+            assert 6 <= lat <= 38, f"{state} latitude out of range"
+            assert 68 <= lon <= 98, f"{state} longitude out of range"

--- a/data-pipeline/tests/test_sanitize.py
+++ b/data-pipeline/tests/test_sanitize.py
@@ -1,0 +1,50 @@
+"""Unit tests for the input-sanitisation helpers in fetch_data."""
+
+import fetch_data
+
+
+class TestSanitizeText:
+    def test_strips_html_tags(self):
+        assert fetch_data.sanitize_text("<b>Ganga</b>") == "Ganga"
+
+    def test_decodes_html_entities(self):
+        assert fetch_data.sanitize_text("A &amp; B") == "A & B"
+
+    def test_removes_null_bytes(self):
+        assert "\x00" not in fetch_data.sanitize_text("a\x00b")
+
+    def test_removes_control_characters(self):
+        assert fetch_data.sanitize_text("a\x07b") == "ab"
+
+    def test_keeps_newlines_and_tabs_but_trims_edges(self):
+        # Newlines/tabs in the interior are preserved; surrounding space is trimmed.
+        assert fetch_data.sanitize_text("  line1\n\tline2  ") == "line1\n\tline2"
+
+    def test_enforces_max_length(self):
+        assert len(fetch_data.sanitize_text("x" * 1000, max_length=10)) == 10
+
+    def test_coerces_non_string_input(self):
+        assert fetch_data.sanitize_text(123) == "123"
+
+    def test_none_becomes_empty_string(self):
+        assert fetch_data.sanitize_text(None) == ""
+
+
+class TestSanitizeRecord:
+    def test_only_listed_fields_are_sanitized(self):
+        record = {"name": "<i>Yamuna</i>", "note": "<b>raw</b>", "value": 5}
+        out = fetch_data.sanitize_record(record, ["name"])
+        assert out["name"] == "Yamuna"
+        assert out["note"] == "<b>raw</b>"  # not in text_fields, left untouched
+        assert out["value"] == 5
+
+    def test_does_not_mutate_the_original_record(self):
+        record = {"name": "<i>Yamuna</i>"}
+        fetch_data.sanitize_record(record, ["name"])
+        assert record["name"] == "<i>Yamuna</i>"
+
+    def test_ignores_missing_and_none_fields(self):
+        record = {"name": None}
+        out = fetch_data.sanitize_record(record, ["name", "absent"])
+        assert out["name"] is None
+        assert "absent" not in out

--- a/frontend/src/__tests__/Header.test.tsx
+++ b/frontend/src/__tests__/Header.test.tsx
@@ -22,9 +22,11 @@ describe('Header Component', () => {
     vi.clearAllMocks();
   });
 
-  it('renders navigation elements', () => {
+  it('renders navigation elements', async () => {
     render(<Header {...defaultProps} />);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    // `findBy*` flushes the async notifications effect so the state update is
+    // wrapped in act(), avoiding React "not wrapped in act(...)" warnings.
+    expect(await screen.findByText('Dashboard')).toBeInTheDocument();
     // Use getAllByLabelText in case of weird duplication, though there should be one
     const notificationButtons = screen.getAllByLabelText('Notifications');
     expect(notificationButtons.length).toBeGreaterThan(0);

--- a/frontend/src/__tests__/smoke.test.tsx
+++ b/frontend/src/__tests__/smoke.test.tsx
@@ -22,8 +22,10 @@ vi.mock('../services/api', () => ({
 }));
 
 describe('frontend smoke', () => {
-  it('runs', () => {
+  it('runs', async () => {
     render(<App />);
-    expect(screen.getByText('Aqua-AI')).toBeInTheDocument();
+    // Await the first paint so the async data-loading effects (notifications,
+    // locations, water quality) settle inside act() and don't warn.
+    expect(await screen.findByText('Aqua-AI')).toBeInTheDocument();
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
     setupFiles: './src/setupTests.ts',
     coverage: {
       provider: 'v8',
+      // `json-summary` is required by the Coverage Report CI job, which reads
+      // coverage/coverage-summary.json to post a PR comment. `text` keeps the
+      // console summary and `html`/`json` remain available for local drill-down.
+      reporter: ['text', 'html', 'json', 'json-summary'],
       include: ['src/**/*.{ts,tsx}'],
       exclude: [
         'src/components/ui/**',

--- a/generate_history.py
+++ b/generate_history.py
@@ -1,50 +1,56 @@
 import subprocess
-import re
-from datetime import datetime
+
 
 def generate_history():
     # Git log command to get details with stats
     # We use a custom separator for parsing
-    cmd = ['git', 'log', '--reverse', '--date=short', '--pretty=format:COMMIT_START%n%H%n%an%n%ad%n%s%n%b%nCOMMIT_BODY_END', '--stat']
-    
+    cmd = [
+        "git",
+        "log",
+        "--reverse",
+        "--date=short",
+        "--pretty=format:COMMIT_START%n%H%n%an%n%ad%n%s%n%b%nCOMMIT_BODY_END",
+        "--stat",
+    ]
+
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8')
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
         if result.returncode != 0:
             print(f"Error running git log: {result.stderr}")
             return
-            
+
         raw_log = result.stdout
-        
+
         # Split by COMMIT_START
-        commits = raw_log.split('COMMIT_START')
-        
+        commits = raw_log.split("COMMIT_START")
+
         markdown_content = "# Comprehensive Project Commit History\n\n"
         markdown_content += "This document provides a detailed historical record of all commits in the repository, chronologically ordered.\n\n"
-        
+
         commit_count = 0
-        
+
         for commit_raw in commits:
             if not commit_raw.strip():
                 continue
-                
+
             commit_count += 1
-            lines = commit_raw.strip().split('\n')
-            
+            lines = commit_raw.strip().split("\n")
+
             # Parsing header
             if len(lines) < 5:
                 continue
-                
+
             commit_hash = lines[0].strip()
             author = lines[1].strip()
             date = lines[2].strip()
             subject = lines[3].strip()
-            
+
             # Extract body and stats
             # Find where COMMIT_BODY_END is
             try:
-                body_end_index = lines.index('COMMIT_BODY_END')
-                body = '\n'.join(lines[4:body_end_index]).strip()
-                stats = '\n'.join(lines[body_end_index+1:]).strip()
+                body_end_index = lines.index("COMMIT_BODY_END")
+                body = "\n".join(lines[4:body_end_index]).strip()
+                stats = "\n".join(lines[body_end_index + 1 :]).strip()
             except ValueError:
                 body = ""
                 stats = ""
@@ -54,13 +60,13 @@ def generate_history():
             markdown_content += f"**Commit Hash:** `{commit_hash}`  \n"
             markdown_content += f"**Author:** {author}  \n"
             markdown_content += f"**Date:** {date}  \n\n"
-            
+
             markdown_content += "### 📝 Description & Impact\n"
             if body:
                 markdown_content += f"{body}\n\n"
             else:
                 markdown_content += f"{subject}\n\n"
-            
+
             # Add some interpretive text based on keywords (simple heuristic to add value)
             markdown_content += "**Context:**\n"
             if "fix" in subject.lower():
@@ -75,9 +81,9 @@ def generate_history():
                 markdown_content += "- **Type:** Maintenance/Dependency Update\n"
             else:
                 markdown_content += "- **Type:** Code Change\n"
-                
+
             markdown_content += "\n"
-            
+
             markdown_content += "### 📂 Changed Files\n"
             if stats:
                 markdown_content += "```text\n"
@@ -85,16 +91,17 @@ def generate_history():
                 markdown_content += "\n```\n\n"
             else:
                 markdown_content += "_No file stats available._\n\n"
-            
+
             markdown_content += "---\n\n"
-            
-        with open('detailed_project_history.md', 'w', encoding='utf-8') as f:
+
+        with open("detailed_project_history.md", "w", encoding="utf-8") as f:
             f.write(markdown_content)
-            
+
         print(f"Successfully processed {commit_count} commits into detailed_project_history.md")
-        
+
     except Exception as e:
         print(f"An error occurred: {str(e)}")
+
 
 if __name__ == "__main__":
     generate_history()

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   # Backend Service
   - type: web
     name: aqua-ai-backend
-    env: node
+    runtime: node
     root: backend
     buildCommand: npm install
     startCommand: npm run migrate && npm start

--- a/verify_a11y.py
+++ b/verify_a11y.py
@@ -1,4 +1,5 @@
-from playwright.sync_api import Page, expect, sync_playwright
+from playwright.sync_api import Page, sync_playwright
+
 
 def verify_a11y(page: Page):
     # Go to app
@@ -18,6 +19,7 @@ def verify_a11y(page: Page):
 
     # Take screenshot of Analytics Page
     page.screenshot(path="analytics_page.png", full_page=True)
+
 
 if __name__ == "__main__":
     with sync_playwright() as p:


### PR DESCRIPTION
## Summary

A repository-wide quality pass across the whole monorepo (backend, frontend, data-pipeline, ai-models). The goal: make the tooling enforce what it claims, clean up the code so it satisfies the project's own linters/formatters, and add real test coverage for the Python side (which previously had **zero** tests).

Everything here was verified locally (see the table below).

## What changed

**Lint / test cleanliness**
- `backend/eslint.config.js`: scope `require-await` off for test files → backend lint goes from **2 warnings → 0**.
- `frontend/src/__tests__/{Header,smoke}.test.tsx`: `await` the async notifications effect so tests no longer emit React `act(...)` warnings.

**Python clean code**
- Ran **Black** (the project's configured formatter) across all Python modules; removed unused imports; fixed `E402` (import order) and `F541` (placeholder-less f-strings); trimmed trailing whitespace in SQL literals.
- Deleted two **dead "doubled" docstrings** in `fetch_data.py` (the second string was evaluated-and-discarded dead code).
- `.flake8`: delegate `E501` to Black (standard Black-compatible config) + ignore vendor/build dirs. **Full `flake8` now passes (was ~200 issues); CI previously only checked 4 rule codes.**

**CI / deployment config**
- `frontend/vite.config.ts`: add the `json-summary` coverage reporter so the **Coverage Report** workflow (`coverage.yml`) actually finds `coverage-summary.json` — it was silently reporting "No coverage data available".
- `render.yaml`: `env: node` → `runtime: node` for the backend service (matches the frontend service + Render's current schema).
- `.gitignore`: ignore `.pytest_cache/`, `.coverage`, `coverage.xml`, `.mypy_cache/`.

**New tests (35 total)**
- `data-pipeline/tests/test_config.py` — `DBConfig` URL parsing/defaults, the missing-password `ValueError` guard, `APIConfig` defaults, threshold + coordinate sanity checks.
- `data-pipeline/tests/test_sanitize.py` — `sanitize_text` / `sanitize_record`.
- `ai-models/tests/test_risk_level.py` — parametrized `_determine_risk_level` (BOD/Nitrates, DO, pH band, unknown fallback), with a `conftest.py` that stubs TensorFlow when it isn't installed.

## Verification (run locally)

| Suite | Result |
|-------|--------|
| Backend lint | 0 warnings (was 2) |
| Backend tests | 72 passed |
| Frontend lint + types | clean |
| Frontend tests | 39 passed, no `act()` warnings |
| Frontend coverage | `coverage-summary.json` now produced |
| Python `black --check` | clean |
| Python `flake8` (repo config) | 0 issues (was ~200) |
| Python `pytest` (repo root) | 35 passed |

## Follow-up not included here
The matching `ci.yml` change (enforce full `flake8` + `black --check` in the `ai-models` job) **could not be pushed** because the automation token lacks GitHub's `workflow` scope. The exact snippet to apply via the GitHub UI is in the explainer doc.

## Explainer doc
📄 Full background/intuition/walkthrough/quiz: https://app.notion.com/p/392c0ee07add816980aeda550b3c00e2

🔗 Task: https://app.notion.com/p/392c0ee07add802abd64c63e611ac628