### PR TITLE
fix: use simple image-based devcontainer instead of production compos…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,5 +40,5 @@
       "onAutoForward": "ignore"
     }
   },
-  "postCreateCommand": "npm install && cd frontend && npm install && cd ../backend && npm install && cd .. && pip install -r requirements.txt"
+  "postCreateCommand": "([ -f .env ] || cp .env.example .env) && npm install && cd frontend && npm install && cd ../backend && npm install && cd .. && pip install -r requirements.txt"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "Aqua-AI Development Container",
-  "dockerComposeFile": "../docker-compose.yml",
-  "service": "backend",
-  "workspaceFolder": "/app",
-  "initializeCommand": "node -e \"const fs = require('fs'); if (!fs.existsSync('.env')) fs.copyFileSync('.env.example', '.env');\"",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "18"
@@ -43,6 +40,5 @@
       "onAutoForward": "ignore"
     }
   },
-  "postCreateCommand": "npm install && cd frontend && npm install && cd ../backend && npm install && cd .. && pip install -r requirements.txt",
-  "remoteUser": "node"
+  "postCreateCommand": "npm install && cd frontend && npm install && cd ../backend && npm install && cd .. && pip install -r requirements.txt"
 }


### PR DESCRIPTION
…e stack

The devcontainer reused the production docker-compose.yml, which booted the entire stack (db, backend, frontend, ai-pipeline, redis) just to provide a dev environment. Production-only settings (strict JWT_SECRET, USER node ownership, npm ci --omit=dev) repeatedly broke the Codespace build.

Switch to a simple image-based devcontainer (Debian bookworm) with the Node, Python, Docker-in-Docker, and Git features. The full stack can still be run inside the Codespace with 'docker compose up'. docker-compose.yml and the Dockerfiles are unchanged for production use.